### PR TITLE
add java11 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <mockito.version>1.9.5</mockito.version>
     <slf4j.version>1.7.6</slf4j.version>
     <wagon.version>2.6</wagon.version>
+    <jaxb.version>2.4.0-b180725.0427</jaxb.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -121,6 +122,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>${jaxb.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Fixes https://app.clubhouse.io/vgs/story/49825/aws-maven-fork-is-not-integrated-w-ci

deployment fails with java 11 and without `jaxb-api`